### PR TITLE
エンティティの振舞interfaceの追加

### DIFF
--- a/src/Entity/Behavior/ComparableInterface.php
+++ b/src/Entity/Behavior/ComparableInterface.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Copyright (c) 2014 GOTO Hidenori <hidenorigoto@gmail.com>,
+ * All rights reserved.
+ *
+ * This file is part of Domain Kata.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\DomainKata\Entity\Behavior;
+
+use PHPMentors\DomainKata\Entity\EntityInterface;
+
+interface ComparableInterface
+{
+    /**
+     * @param \PHPMentors\DomainKata\Entity\EntityInterface $target
+     * @return integer
+     */
+    public function compareTo(EntityInterface $target);
+}

--- a/src/Entity/Behavior/CopyableInterface.php
+++ b/src/Entity/Behavior/CopyableInterface.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Copyright (c) 2014 GOTO Hidenori <hidenorigoto@gmail.com>,
+ * All rights reserved.
+ *
+ * This file is part of Domain Kata.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\DomainKata\Entity\Behavior;
+
+use PHPMentors\DomainKata\Entity\EntityInterface;
+
+interface CopyableInterface
+{
+    /**
+     * @param \PHPMentors\DomainKata\Entity\EntityInterface $from
+     * @return bool
+     */
+    public function copyFrom(EntityInterface $from);
+}

--- a/src/Entity/Behavior/EqualableInterface.php
+++ b/src/Entity/Behavior/EqualableInterface.php
@@ -1,0 +1,24 @@
+<?php
+/*
+ * Copyright (c) 2014 GOTO Hidenori <hidenorigoto@gmail.com>,
+ * All rights reserved.
+ *
+ * This file is part of Domain Kata.
+ *
+ * This program and the accompanying materials are made available under
+ * the terms of the BSD 2-Clause License which accompanies this
+ * distribution, and is available at http://opensource.org/licenses/BSD-2-Clause
+ */
+
+namespace PHPMentors\DomainKata\Entity\Behavior;
+
+use PHPMentors\DomainKata\Entity\EntityInterface;
+
+interface EqualableInterface
+{
+    /**
+     * @param \PHPMentors\DomainKata\Entity\EntityInterface $target
+     * @return bool
+     */
+    public function equalTo(EntityInterface $target);
+}


### PR DESCRIPTION
次の3つのインターフェイスを追加
- ComparableInterface
- CopyableInterface
- EqualableInterface

これらは「同一種のエンティティクラスのインスタンス同士」で使うことを想定しています。
## ComparableInterface

エンティティの順序付けを規程します。利用ケースはそれほど多くはないかと思いますが、コード内で並べ替えを記述する場合に、その判断文の置き場所となります。
## CopyableInterface

エンティティインスタンスの値を、同一クラスの別インスタンスからコピーするメソッドを規程します。
## EqualableInterface

エンティティインスタンスの指す対象が同一かどうかを返すメソッドを規程します。

私はEqualableInterface（同一比較）はすべてのエンティティクラスで実装して使っています。これと比べると他の２つの利用頻度は下がります。

CopyableInterfaceは、使い方を含めて議論の余地が多くあります。私の実装では、エンティティの「ID以外」の値をコピーする機能として使っています。既存のデータを編集するフォームを実装する時に、フォームに入力された値（フォームDTOのインスタンス）からエンティティのインスタンスへデータをコピーします。
（この意味では、エンティティ側に `copyFrom()` を書くのではなく、DTO 側に `copyTo()` を用意すべきかもしれませんね）
